### PR TITLE
Relax regex parsing of changelog line items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-capital-framework",
   "description": "A Hubot script to manage CFPB's Capital Framework",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": "Chris Contolini <contolini@users.noreply.github.com>",
   "license": "CC0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-capital-framework",
   "description": "A Hubot script to manage CFPB's Capital Framework",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "author": "Chris Contolini <contolini@users.noreply.github.com>",
   "license": "CC0",
   "keywords": [

--- a/src/lib/changelog.coffee
+++ b/src/lib/changelog.coffee
@@ -12,7 +12,7 @@ updateChangelog = (tmpLocation, changelogLocation, packageLocation, cb) ->
 
   # Grab the "Unreleased" section and split it by markdown h3's
   version = pkg.version.replace(/\./g, '\\.')
-  unreleasedSection = changelog.match(new RegExp "(?=## Unreleased)([\\s\\S]+)(?=\n## #{version})", "igm")[0]
+  unreleasedSection = changelog.match(new RegExp "(?=## Unreleased)([\\s\\S]+?)(?=\n## [0-9]+?\.[0-9]+?\.[0-9]+?)", "igm")[0]
   lines = unreleasedSection.split('### ').filter((line) -> return line).slice(1)
 
   # Organize the unreleased changelog items by type ("added", "changed", or "removed")

--- a/src/lib/changelog.coffee
+++ b/src/lib/changelog.coffee
@@ -25,7 +25,7 @@ updateChangelog = (tmpLocation, changelogLocation, packageLocation, cb) ->
   types = do ->
     components = {}
     bumpType = "(\\[?(major|minor|patch)\\]?)"
-    componentName = "(\\*\\*(cf\\-[\\w\\-]+|all components|capital\\-framework):?\\*\\*)"
+    componentName = "(\\*\\*(cf\\-[\\w\\-]+|all components|capital\\-framework):?\\*\\*):?"
     notes = "([\\s\\S]+)"
     re = new RegExp "#{bumpType}?\\s?#{componentName}\\s+#{bumpType}?#{notes}", "i"
     for type of types

--- a/test/fixtures/changelog-cf.md
+++ b/test/fixtures/changelog-cf.md
@@ -12,17 +12,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 ### Removed
 -
 
-## 3.4.1 - 2016-05-13
+## 3.4.0 - 2016-05-13
 
 ### Changed
 - **capital-framework:** Update contributing documentation.
-
-
-## 3.4.0 - 2016-05-09
-
-### Changed
-- **cf-layout:** Updated main content spacing
-
 
 ## 3.3.0 - 2016-04-06
 

--- a/test/fixtures/changelog-cf_expected.md
+++ b/test/fixtures/changelog-cf_expected.md
@@ -7,17 +7,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - **capital-framework:** Eat tortellini till your lungs explode.
 
 
-## 3.4.1 - 2016-05-13
+## 3.4.0 - 2016-05-13
 
 ### Changed
 - **capital-framework:** Update contributing documentation.
-
-
-## 3.4.0 - 2016-05-09
-
-### Changed
-- **cf-layout:** Updated main content spacing
-
 
 ## 3.3.0 - 2016-04-06
 

--- a/test/fixtures/changelog-colon.md
+++ b/test/fixtures/changelog-colon.md
@@ -1,0 +1,132 @@
+All notable changes to this project will be documented in this file.
+We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
+
+## Unreleased
+
+### Added
+- **cf-core:** [MINOR] Add respond-to-dpi mixin and respond-to-print mixin
+
+### Changed
+- **cf-tables:** [PATCH] Update link to 18F Web Design Standards
+- **cf-typography**: [PATCH] Update link to 18F Web Design Standards
+
+### Removed
+- **cf-typography:** [MAJOR] Update link to 18F Web Design Standards
+
+## 3.4.1 - 2016-05-13
+
+### Changed
+- **capital-framework:** Update contributing documentation.
+
+
+## 3.4.0 - 2016-05-09
+
+### Changed
+- **cf-layout:** Updated main content spacing
+
+
+## 3.3.0 - 2016-04-06
+
+### Added
+- **cf-layout:** Add `overlay` and `white-text` modifiers to the hero
+
+### Changed
+- **capital-framework:** Move Travis CI from Node v4 to v5.
+- **cf-core:** Fix padding in `<th>`s to be 10px.
+- **cf-tables:** Match sortable `<th>` styles to non-sortable `<th>` styles.
+- **cf-tables:** Harmonize variables with those found in cf-core.
+- **cf-layout:** Updated the Hero styles to properly match the content layout and simplified the rules.
+
+## 3.2.1 - 2016-03-10
+
+### Changed
+- **All components:** Normalize markdown formatting across usage.md files.
+
+
+## 3.2.0 - 2016-02-26
+
+### Added
+- **cf-tables:** Add new component.
+- **cf-core:** Add font-size vars.
+
+
+## 3.1.4 - 2016-02-23
+
+### Changed
+- Include `usage.md` in built components.
+
+
+## 3.1.3 - 2016-02-23
+
+### Changed
+
+- Update build process to include `usage.md` with built components.
+
+
+## 3.1.2 - 2016-02-10
+
+### Fixed
+- **cf-core:** Fix improper usage of `:not` to target non-nav `li` elements.
+- **cf-core:** Remove `margin-bottom` from last-child `li` elements.
+- **cf-layout:** Fix a bug where columns nested 2 levels deep in a
+  large-gutter modifier gain the extra wide gutters.
+- **cf-layout:** Remove `block` borders when `__flush` modifiers are also applied.
+- **capital-framework:** Added `CONTRIBUTING.md` with contribution docs.
+
+### Changed
+- **cf-layout:** Hero updates:
+  - Use new breakpoint variables
+  - Subheading should not be medium on smaller screens
+  - CTA links should match size and weight of subheading
+  - Margin between subheading and CTA is 30px
+
+
+## 3.1.1 - 2016-01-04
+
+### Changed
+- **capital-framework:** Improve contributing docs in readme.
+
+
+## 3.1.0 - 2016-01-04
+
+### Changed
+- **capital-framework:** Edit Gulp styles task to use Less' `paths` option instead of npm import plugin.
+- **cf-core:** Update `normalize.css` `@import` paths to play nicer with Less `paths` option.
+- **cf-grid:** Update `normalize.css` `@import` paths to play nicer with Less `paths` option.
+- **cf-icons:** Replace icon fonts to fix "Failed to decode downloaded font" error.
+
+
+## 3.0.8 - 2015-12-22
+
+### Added
+- Ability to publish CF from local machine (instead of only Travis).
+
+
+## 3.0.7 - 2015-12-22
+
+### Removed
+- Topdoc comments from component source files.
+
+
+## 3.0.6 - 2015-12-18
+
+### Added
+- Initial WCAG accessibility tests.
+
+
+## 3.0.5 - 2015-12-18
+
+### Changed
+- Individual components' readme template.
+
+
+## 3.0.3 - 2015-12-18
+
+### Added
+- Add automatic changelog updating to Travis CI release script.
+
+
+## 3.0.0 - 2015-12-17
+
+### Changed
+- Voltrazord refactor. All components now live in this repo.

--- a/test/fixtures/changelog-colon_expected.md
+++ b/test/fixtures/changelog-colon_expected.md
@@ -1,0 +1,133 @@
+All notable changes to this project will be documented in this file.
+We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
+
+## Unreleased
+
+### Added
+- **cf-core:** Add respond-to-dpi mixin and respond-to-print mixin
+
+### Changed
+- **cf-tables:** Update link to 18F Web Design Standards
+- **cf-typography:** Update link to 18F Web Design Standards
+
+### Removed
+- **cf-typography:** Update link to 18F Web Design Standards
+
+
+## 3.4.1 - 2016-05-13
+
+### Changed
+- **capital-framework:** Update contributing documentation.
+
+
+## 3.4.0 - 2016-05-09
+
+### Changed
+- **cf-layout:** Updated main content spacing
+
+
+## 3.3.0 - 2016-04-06
+
+### Added
+- **cf-layout:** Add `overlay` and `white-text` modifiers to the hero
+
+### Changed
+- **capital-framework:** Move Travis CI from Node v4 to v5.
+- **cf-core:** Fix padding in `<th>`s to be 10px.
+- **cf-tables:** Match sortable `<th>` styles to non-sortable `<th>` styles.
+- **cf-tables:** Harmonize variables with those found in cf-core.
+- **cf-layout:** Updated the Hero styles to properly match the content layout and simplified the rules.
+
+## 3.2.1 - 2016-03-10
+
+### Changed
+- **All components:** Normalize markdown formatting across usage.md files.
+
+
+## 3.2.0 - 2016-02-26
+
+### Added
+- **cf-tables:** Add new component.
+- **cf-core:** Add font-size vars.
+
+
+## 3.1.4 - 2016-02-23
+
+### Changed
+- Include `usage.md` in built components.
+
+
+## 3.1.3 - 2016-02-23
+
+### Changed
+
+- Update build process to include `usage.md` with built components.
+
+
+## 3.1.2 - 2016-02-10
+
+### Fixed
+- **cf-core:** Fix improper usage of `:not` to target non-nav `li` elements.
+- **cf-core:** Remove `margin-bottom` from last-child `li` elements.
+- **cf-layout:** Fix a bug where columns nested 2 levels deep in a
+  large-gutter modifier gain the extra wide gutters.
+- **cf-layout:** Remove `block` borders when `__flush` modifiers are also applied.
+- **capital-framework:** Added `CONTRIBUTING.md` with contribution docs.
+
+### Changed
+- **cf-layout:** Hero updates:
+  - Use new breakpoint variables
+  - Subheading should not be medium on smaller screens
+  - CTA links should match size and weight of subheading
+  - Margin between subheading and CTA is 30px
+
+
+## 3.1.1 - 2016-01-04
+
+### Changed
+- **capital-framework:** Improve contributing docs in readme.
+
+
+## 3.1.0 - 2016-01-04
+
+### Changed
+- **capital-framework:** Edit Gulp styles task to use Less' `paths` option instead of npm import plugin.
+- **cf-core:** Update `normalize.css` `@import` paths to play nicer with Less `paths` option.
+- **cf-grid:** Update `normalize.css` `@import` paths to play nicer with Less `paths` option.
+- **cf-icons:** Replace icon fonts to fix "Failed to decode downloaded font" error.
+
+
+## 3.0.8 - 2015-12-22
+
+### Added
+- Ability to publish CF from local machine (instead of only Travis).
+
+
+## 3.0.7 - 2015-12-22
+
+### Removed
+- Topdoc comments from component source files.
+
+
+## 3.0.6 - 2015-12-18
+
+### Added
+- Initial WCAG accessibility tests.
+
+
+## 3.0.5 - 2015-12-18
+
+### Changed
+- Individual components' readme template.
+
+
+## 3.0.3 - 2015-12-18
+
+### Added
+- Add automatic changelog updating to Travis CI release script.
+
+
+## 3.0.0 - 2015-12-17
+
+### Changed
+- Voltrazord refactor. All components now live in this repo.

--- a/test/lib/changelog-test.coffee
+++ b/test/lib/changelog-test.coffee
@@ -36,8 +36,8 @@ changelogTest = (name, done) ->
     expect(after).to.equal(before)
     do done
 
-describe 'capital-framework', ->
-  @timeout 10000
+describe 'capital-framework changelog', ->
+  @timeout 20000
 
   before (done) ->
     tmp.dir {mode: '777', unsafeCleanup: false}, (err, tmpath, cleanup) ->

--- a/test/lib/changelog-test.coffee
+++ b/test/lib/changelog-test.coffee
@@ -76,3 +76,6 @@ describe 'capital-framework changelog', ->
 
     it 'processes a changelog of only "capital-framework"', (done) ->
       changelogTest 'cf', done
+
+    it 'processes a changelog even if the markdown is a little weird', (done) ->
+      changelogTest 'colon', done


### PR DESCRIPTION
Now colons can go inside or outside the `**`! Hooray!

This also includes the previous 1.5.0 fix that I apparently never pushed up to GitHub.