### PR TITLE
Add list of projects with dependencies on CF

### DIFF
--- a/src/lib/pull-request.coffee
+++ b/src/lib/pull-request.coffee
@@ -25,6 +25,15 @@ pr = (token, branch, body, cb) ->
   If I do something wrong, [blame a human](https://github.com/cfpb/hubot-capital-framework/issues/new).
 
   ![kitten gif](http://thecatapi.com/api/images/get?format=src&type=gif)
+
+  ## You are not
+
+  After this PR is merged, you should be prepared to update the CF dependencies I've released in the following projects:
+
+  - [ ] [capital-framework gh-pages branch](https://github.com/cfpb/capital-framework/tree/gh-pages)
+  - [ ] [design-manual](https://github.com/cfpb/design-manual/)
+  - [ ] [generator-cf](https://github.com/cfpb/generator-cf/)
+  - [ ] [cfgov-refresh](https://github.com/cfpb/cfgov-refresh/)
   """
 
   github.pullRequests.create user: 'cfpb', repo: 'capital-framework', title: 'CF Release', base: 'master', head: branch, body: body, (err, data) ->

--- a/src/lib/pull-request.coffee
+++ b/src/lib/pull-request.coffee
@@ -31,13 +31,13 @@ pr = (token, branch, body, cb) ->
   After this PR is merged, you should be prepared to update the CF dependencies I've released in the following projects:
 
   - [ ] [capital-framework gh-pages branch](https://github.com/cfpb/capital-framework/tree/gh-pages) - 
-        The documentation site for Capital Framework, entire repo could be affected.
+        The documentation site for Capital Framework, entire repo (including build process) could be affected.
   - [ ] [design-manual](https://github.com/cfpb/design-manual/) - 
-        The documentation site for the Design Manual, entire repo could be affected.
+        The documentation site for the Design Manual, entire repo (including build process) could be affected.
   - [ ] [generator-cf](https://github.com/cfpb/generator-cf/) - 
         The Yeoman generator for creating new CFPB projects, only the app/templates directory should be affected.
   - [ ] [cfgov-refresh](https://github.com/cfpb/cfgov-refresh/) - 
-        The CFPB website, cfgov/jinja2/v1, cfgov/unprocessed, and cfgov/wellbeing could all be affected.
+        The CFPB website, build process, cfgov/jinja2/v1, cfgov/unprocessed, and cfgov/wellbeing could all be affected.
   """
 
   github.pullRequests.create user: 'cfpb', repo: 'capital-framework', title: 'CF Release', base: 'master', head: branch, body: body, (err, data) ->

--- a/src/lib/pull-request.coffee
+++ b/src/lib/pull-request.coffee
@@ -30,10 +30,14 @@ pr = (token, branch, body, cb) ->
 
   After this PR is merged, you should be prepared to update the CF dependencies I've released in the following projects:
 
-  - [ ] [capital-framework gh-pages branch](https://github.com/cfpb/capital-framework/tree/gh-pages)
-  - [ ] [design-manual](https://github.com/cfpb/design-manual/)
-  - [ ] [generator-cf](https://github.com/cfpb/generator-cf/)
-  - [ ] [cfgov-refresh](https://github.com/cfpb/cfgov-refresh/)
+  - [ ] [capital-framework gh-pages branch](https://github.com/cfpb/capital-framework/tree/gh-pages) - 
+        The documentation site for Capital Framework, entire repo could be affected.
+  - [ ] [design-manual](https://github.com/cfpb/design-manual/) - 
+        The documentation site for the Design Manual, entire repo could be affected.
+  - [ ] [generator-cf](https://github.com/cfpb/generator-cf/) - 
+        The Yeoman generator for creating new CFPB projects, only the app/templates directory should be affected.
+  - [ ] [cfgov-refresh](https://github.com/cfpb/cfgov-refresh/) - 
+        The CFPB website, cfgov/jinja2/v1, cfgov/unprocessed, and cfgov/wellbeing could all be affected.
   """
 
   github.pullRequests.create user: 'cfpb', repo: 'capital-framework', title: 'CF Release', base: 'master', head: branch, body: body, (err, data) ->


### PR DESCRIPTION
We have not been great about updating the main projects that rely on being up to date with Capital Framework. Hopefully this handy checklist will help us keep track of what is and isn't updated after a release.